### PR TITLE
added an issue template copied from the readme

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+Bug/error being reported:
+Steps to reproduce:
+Expected result:
+Actual result:


### PR DESCRIPTION
Just a way to add the issue template in the readme to all new issues by default, may save you all a little time since this repo has been pretty busy.